### PR TITLE
Remove unnecessary panic for unreachable code

### DIFF
--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -500,16 +500,21 @@ impl Connection {
                     Err(err)
                 }
             },
-            false => match &mut self.results_iter {
-                Some(it) => match it.next() {
-                    Some(x) => Ok(Some(x)),
-                    None => {
-                        self.status = ConnectionStatus::Ready;
-                        Ok(None)
-                    }
-                },
-                None => panic!(),
-            },
+            false => match self.next_record() {
+                Some(x) => Ok(Some(x)),
+                None => {
+                    self.status = ConnectionStatus::Ready;
+                    Ok(None)
+                }
+            }
+        }
+    }
+
+    fn next_record(&mut self) -> Option<Record> {
+        if let Some(iter) = self.results_iter.as_mut() {
+            iter.next()
+        } else {
+            None
         }
     }
 

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -506,7 +506,7 @@ impl Connection {
                     self.status = ConnectionStatus::Ready;
                     Ok(None)
                 }
-            }
+            },
         }
     }
 

--- a/src/connection/tests.rs
+++ b/src/connection/tests.rs
@@ -210,8 +210,7 @@ fn from_connect_fetchone_no_data() {
     let first = connection.fetchone();
     if let Ok(rec) = first {
         assert!(rec.is_none());
-    }
-    else {
+    } else {
         panic!("First fetched record should be None")
     }
 }

--- a/src/connection/tests.rs
+++ b/src/connection/tests.rs
@@ -184,8 +184,7 @@ fn from_connect_fetchone_address() {
 
 #[test]
 #[serial]
-#[should_panic(expected = "explicit panic")]
-fn from_connect_fetchone_explicit_panic() {
+fn from_connect_fetchone_no_data() {
     initialize();
     execute_query(String::from(
         "CREATE (u:User {name: 'Alice'})-[:Likes]->(m:Software {name: 'Memgraph'})",
@@ -200,39 +199,20 @@ fn from_connect_fetchone_explicit_panic() {
         ..Default::default()
     };
     let mut connection = get_connection(connect_prms);
-    let params = get_params("name".to_string(), "Alice".to_string());
+    let params = get_params("name".to_string(), "Something".to_string());
 
     let query = String::from("MATCH (n:User) WHERE n.name = $name RETURN n LIMIT 5");
     match connection.execute(&query, Some(&params)) {
         Ok(x) => x,
         Err(err) => panic!("Query failed: {}", err),
     };
-    connection.results_iter = None;
-    loop {
-        match connection.fetchone() {
-            Ok(res) => match res {
-                Some(x) => {
-                    for val in &x.values {
-                        let values = vec![String::from("User")];
-                        let mg_map = hashmap! {
-                            String::from("name") => Value::String("Alice".to_string()),
-                        };
-                        let node = Value::Node(Node {
-                            id: match val {
-                                Value::Node(x) => x.id,
-                                _ => 1,
-                            },
-                            label_count: 1,
-                            labels: values,
-                            properties: mg_map,
-                        });
-                        assert_eq!(&node, val);
-                    }
-                }
-                None => break,
-            },
-            Err(err) => panic!("Fetch failed: {}", err),
-        }
+
+    let first = connection.fetchone();
+    if let Ok(rec) = first {
+        assert!(rec.is_none());
+    }
+    else {
+        panic!("First fetched record should be None")
     }
 }
 


### PR DESCRIPTION
This PR removes unnecessary panic for unreachable code
and unifies behavior for lazy and eager data fetching.

Although [std::unreachable!()](https://doc.rust-lang.org/std/macro.unreachable.html) could be used here and 
serve as self explanatory there is no reason for keeping 
this behavior in a lib API  that returns a Result type.

Test is rewritten since as far as I can see it was just a c/p where 
no data was fetched in loop but code would panic on first
fetchone fn invocations since result was explicitly set  to None. 

 