### PR TITLE
Make Connection::status return ConnectionStatus instead of &ConnectionStatus

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Once `rsmgclient` is cloned, you will need to build it and then you can run
 the test suite to verify it is working correctly:
 
 ```bash
+git submodule update --init
 cargo build
 # Run Memgraph based on the quick start guide
 cargo test

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2020 Memgraph Ltd. [https://memgraph.com]
+// Copyright (c) 2016-2022 Memgraph Ltd. [https://memgraph.com]
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -101,7 +101,7 @@ impl Default for ConnectParams {
 }
 
 /// Determines whether a secure SSL TCP/IP connection will be negotiated with the server.
-#[derive(PartialEq)]
+#[derive(PartialEq, Eq)]
 pub enum SSLMode {
     /// Only try a non-SSL connection.
     Disable,
@@ -146,7 +146,7 @@ pub struct Connection {
 }
 
 /// Representation of current connection status.
-#[derive(PartialEq, Debug, Clone, Copy)]
+#[derive(PartialEq, Eq, Debug, Clone, Copy)]
 #[repr(u8)]
 pub enum ConnectionStatus {
     /// Connection is ready to start executing.

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -146,7 +146,8 @@ pub struct Connection {
 }
 
 /// Representation of current connection status.
-#[derive(PartialEq, Debug)]
+#[derive(PartialEq, Debug, Clone, Copy)]
+#[repr(u8)]
 pub enum ConnectionStatus {
     /// Connection is ready to start executing.
     Ready,
@@ -224,8 +225,8 @@ impl Connection {
     }
 
     /// Returns current connection status.
-    pub fn status(&self) -> &ConnectionStatus {
-        &self.status
+    pub fn status(&self) -> ConnectionStatus {
+        self.status
     }
 
     /// Returns query summary if it is present.

--- a/src/connection/tests.rs
+++ b/src/connection/tests.rs
@@ -631,7 +631,7 @@ fn fetchall_set_get_arraysize() {
 fn close() {
     let mut connection = initialize();
     connection.close();
-    assert_eq!(ConnectionStatus::Closed, *connection.status());
+    assert_eq!(ConnectionStatus::Closed, connection.status());
 }
 
 #[test]
@@ -660,13 +660,13 @@ fn execute_without_results() {
     assert!(connection
         .execute_without_results("CREATE (n1) CREATE (n2) RETURN n1, n2;")
         .is_ok());
-    assert_eq!(&ConnectionStatus::Ready, connection.status());
+    assert_eq!(ConnectionStatus::Ready, connection.status());
 
     assert!(connection.execute("MATCH (n) RETURN n;", None).is_ok());
-    assert_eq!(&ConnectionStatus::Executing, connection.status());
+    assert_eq!(ConnectionStatus::Executing, connection.status());
     match connection.fetchall() {
         Ok(records) => assert_eq!(records.len(), 2),
         Err(err) => panic!("Failed to get data after execute without results {}.", err),
     }
-    assert_eq!(&ConnectionStatus::InTransaction, connection.status());
+    assert_eq!(ConnectionStatus::InTransaction, connection.status());
 }

--- a/src/connection/tests.rs
+++ b/src/connection/tests.rs
@@ -3,14 +3,14 @@ use crate::{Node, Value};
 use serial_test::serial;
 
 fn get_connection(prms: &ConnectParams) -> Connection {
-    match Connection::connect(&prms) {
+    match Connection::connect(prms) {
         Ok(c) => c,
         Err(err) => panic!("Creating connection failed: {}", err),
     }
 }
 
 fn execute_query(connection: &mut Connection, query: &str) -> Vec<String> {
-    match connection.execute(&query, None) {
+    match connection.execute(query, None) {
         Ok(x) => x,
         Err(err) => panic!("Executing query failed: {}", err),
     }
@@ -25,7 +25,7 @@ fn execute_query_and_fetchall(query: &str) -> Vec<Record> {
     let mut connection = get_connection(&connect_prms);
     assert_eq!(connection.status, ConnectionStatus::Ready);
 
-    match connection.execute(&query, None) {
+    match connection.execute(query, None) {
         Ok(x) => x,
         Err(err) => panic!("Executing query failed: {}", err),
     };
@@ -217,7 +217,7 @@ fn test_fetchone_person_alice(connection: &mut Connection) {
     match &record.values[0] {
         Value::Node(n) => {
             assert_eq_nodes(
-                &n,
+                n,
                 &create_node(
                     vec!["Person".to_string()],
                     hashmap! {"name".to_string() => Value::String("Alice".to_string())},

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -1,4 +1,4 @@
-// Copyright (c) 2016-2020 Memgraph Ltd. [https://memgraph.com]
+// Copyright (c) 2016-2022 Memgraph Ltd. [https://memgraph.com]
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -519,7 +519,7 @@ fn mg_map_to_string(mg_map: &HashMap<String, Value>) -> String {
     for (key, value) in sorted {
         properties.push(format!("'{}': {}", key, value));
     }
-    return format!("{{{}}}", properties.join(", "));
+    format!("{{{}}}", properties.join(", "))
 }
 
 impl fmt::Display for Node {


### PR DESCRIPTION
* make ConnectionStatus implement Copy so that it can be memcpy'd 
* return it from Connection::status
* update install steps on README to include submodule init for mgclient

note: this is an API-breaking change, and we will need to bump the major version to maintain semver compatibility.