### PR TITLE
Polish Linux, Mac and Windows builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,23 +40,11 @@ jobs:
       run: cargo fmt -- --check
     - name: Build the project
       run: cargo build --verbose
-
     - name: Run Memgraph
       run: |
         docker run -d -p 7687:7687 memgraph --telemetry-enabled=False
-
     - name: Run test
       run: cargo test
-    # - name: Run cargo-tarpaulin
-    #   uses: actions-rs/tarpaulin@v0.1.0
-    #   with:
-    #     version: '0.25.0'
-    #     args: '--out Html --ignore-tests --exclude-files mgclient/*'
-    # - name: Archive code coverage results
-    #   uses: actions/upload-artifact@v1
-    #   with:
-    #     name: code-coverage-report
-    #     path: tarpaulin-report.html
 
   build_macos:
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,7 @@ jobs:
     - name: Run cargo-tarpaulin
       uses: actions-rs/tarpaulin@v0.1.0
       with:
+        version: '0.25.0'
         args: '--out Html --ignore-tests --exclude-files mgclient/*'
     - name: Archive code coverage results
       uses: actions/upload-artifact@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
      matrix:
         platform: [ubuntu-20.04, ubuntu-22.04]
-        mgversion: [2.3.1]
+        mgversion: [2.5.2]
     runs-on: ${{ matrix.platform }}
 
     steps:
@@ -45,16 +45,18 @@ jobs:
       run: |
         docker run -d -p 7687:7687 memgraph --telemetry-enabled=False
 
-    - name: Run cargo-tarpaulin
-      uses: actions-rs/tarpaulin@v0.1.0
-      with:
-        version: '0.25.0'
-        args: '--out Html --ignore-tests --exclude-files mgclient/*'
-    - name: Archive code coverage results
-      uses: actions/upload-artifact@v1
-      with:
-        name: code-coverage-report
-        path: tarpaulin-report.html
+    - name: Run test
+      run: cargo test
+    # - name: Run cargo-tarpaulin
+    #   uses: actions-rs/tarpaulin@v0.1.0
+    #   with:
+    #     version: '0.25.0'
+    #     args: '--out Html --ignore-tests --exclude-files mgclient/*'
+    # - name: Archive code coverage results
+    #   uses: actions/upload-artifact@v1
+    #   with:
+    #     name: code-coverage-report
+    #     path: tarpaulin-report.html
 
   build_macos:
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
         docker run -d -p 7687:7687 memgraph --telemetry-enabled=False
 
     - name: Run cargo-tarpaulin
-      uses: actions-rs/tarpaulin@v0.1.3
+      uses: actions-rs/tarpaulin@v0.1.0
       with:
         args: '--out Html --ignore-tests --exclude-files mgclient/*'
     - name: Archive code coverage results

--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ own Rust project, you can install it by using `cargo`:
 cargo install rsmgclient
 ```
 
+NOTE: The default OpenSSL path is `C:\Program Files\OpenSSL-Win64\lib`, if you
+would like to change that please provide `OPENSSL_LIB_DIR` env variable.
+
 ### Building from Source
 
 To contribute into `rsmgclient` or just looking closely how it is made,

--- a/README.md
+++ b/README.md
@@ -43,14 +43,19 @@ the test suite to verify it is working correctly:
 ```bash
 git submodule update --init
 cargo build
-# Run Memgraph based on the quick start guide
+# Please run Memgraph based on the quick start guide
 cargo test
 ```
+
+On MacOS, the build will try to detect OpenSSL by using MacPorts or Brew.
 
 On Windows, `bindgen` requires `libclang` which is a part of LLVM. If LLVM is
 not already installed just go to the [LLVM
 download](https://releases.llvm.org/download.html) page, download and install
-`LLVM.exe` file (select the option to put LLVM on the PATH).
+`LLVM.exe` file (select the option to put LLVM on the PATH). In addition,
+default OpenSSL path is `C:\Program Files\OpenSSL-Win64\lib`, if you would like
+to change that please provide `OPENSSL_LIB_DIR` env variable during the build
+phase.
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -34,17 +34,23 @@ To contribute into `rsmgclient` or just looking closely how it is made,
 you will need:
 
 - Cloned [rsmgclient](https://github.com/memgraph/rsmgclient) repository
+- Properly initialized [mgclient](https://github.com/memgraph/mgclient), please
+  take care of the `mgclient` requirements
 - [Memgraph Quick Start Guide](https://memgraph.com/docs/memgraph/quick-start)
 
 Once `rsmgclient` is cloned, you will need to build it and then you can run
 the test suite to verify it is working correctly:
-
 ```bash
 git submodule update --init
 cargo build
 # Run Memgraph based on the quick start guide
 cargo test
 ```
+
+On Windows, `bindgen` requires `libclang` which is a part of LLVM. If LLVM is
+not already installed just go to the [LLVM
+download](https://releases.llvm.org/download.html) page, download and install
+`LLVM.exe` file (select the option to put LLVM on the PATH).
 
 ## Documentation
 

--- a/build.rs
+++ b/build.rs
@@ -70,8 +70,6 @@ fn build_mgclient_macos() -> PathBuf {
             "cargo:rustc-link-search=native={}",
             openssl_lib_dir.display()
         );
-        println!("cargo:rustc-link-lib=dylib=crypto");
-        println!("cargo:rustc-link-lib=dylib=ssl");
         // With MacPorts, you don't need to pass in the OPENSSL_ROOT_DIR,
         // OPENSSL_CRYPTO_LIBRARY, and OPENSSL_SSL_LIBRARY options to CMake, PkgConfig
         // should take care of setting those variables.
@@ -113,8 +111,6 @@ fn build_mgclient_macos() -> PathBuf {
             "cargo:rustc-link-search=native={}",
             openssl_root_path.join("lib").display()
         );
-        println!("cargo:rustc-link-lib=dylib=crypto");
-        println!("cargo:rustc-link-lib=dylib=ssl");
         let openssl_root = openssl_dirs[0].clone();
         Config::new("mgclient")
             .define("OPENSSL_ROOT_DIR", format!("{}", openssl_root.display()))
@@ -137,8 +133,6 @@ fn build_mgclient_macos() -> PathBuf {
 }
 
 fn build_mgclient_linux() -> PathBuf {
-    println!("cargo:rustc-link-lib=dylib=crypto");
-    println!("cargo:rustc-link-lib=dylib=ssl");
     Config::new("mgclient").build()
 }
 
@@ -148,8 +142,6 @@ fn build_mgclient_windows() -> PathBuf {
             .unwrap_or_else(|_| "C:\\Program Files\\OpenSSL-Win64\\lib".to_string()),
     );
     println!("cargo:rustc-link-search=native={}", openssl_dir.display());
-    println!("cargo:rustc-link-lib=dylib=libcrypto");
-    println!("cargo:rustc-link-lib=dylib=libssl");
     Config::new("mgclient")
         .define("OPENSSL_ROOT_DIR", format!("{}", openssl_dir.display()))
         .build()
@@ -198,4 +190,19 @@ fn main() {
         mgclient_out.join("lib").display()
     );
     println!("cargo:rustc-link-lib=static=mgclient");
+    match host_type {
+        HostType::Linux => {
+            println!("cargo:rustc-link-lib=dylib=crypto");
+            println!("cargo:rustc-link-lib=dylib=ssl");
+        }
+        HostType::Windows => {
+            println!("cargo:rustc-link-lib=dylib=libcrypto");
+            println!("cargo:rustc-link-lib=dylib=libssl");
+        }
+        HostType::MacOS => {
+            println!("cargo:rustc-link-lib=dylib=crypto");
+            println!("cargo:rustc-link-lib=dylib=ssl");
+        }
+        HostType::Unknown => panic!("Unknown operating system"),
+    }
 }

--- a/build.rs
+++ b/build.rs
@@ -187,6 +187,15 @@ fn main() {
         mgclient_out.join("lib").display()
     );
     println!("cargo:rustc-link-lib=static=mgclient");
-    println!("cargo:rustc-link-lib=dylib=crypto");
-    println!("cargo:rustc-link-lib=dylib=ssl");
+    match host_type {
+        HostType::Windows => {
+            println!("cargo:rustc-link-search=native=C:\\Program Files\\OpenSSL-Win64\\lib");
+            println!("cargo:rustc-link-lib=dylib=libcrypto");
+            println!("cargo:rustc-link-lib=dylib=libssl");
+        }
+        _ => {
+            println!("cargo:rustc-link-lib=dylib=crypto");
+            println!("cargo:rustc-link-lib=dylib=ssl");
+        }
+    }
 }

--- a/build.rs
+++ b/build.rs
@@ -40,10 +40,6 @@ fn main() {
 
     let mgclient = PathBuf::new().join("mgclient");
     let mgclient_out = match host_type {
-        // Please checkout what are Windows requirements to compile
-        // https://github.com/memgraph/mgclient.
-        // While installing Rust please select x86_64-pc-windows-gnu
-        // as the host triplet (custom installation step is required).
         HostType::Windows => Config::new("mgclient").build(),
 
         HostType::MacOS => {

--- a/build.rs
+++ b/build.rs
@@ -190,6 +190,8 @@ fn main() {
         mgclient_out.join("lib").display()
     );
     println!("cargo:rustc-link-lib=static=mgclient");
+    // If the following part of the code is pushed inside build_mgclient_xzy, linking is not done
+    // properly.
     match host_type {
         HostType::Linux => {
             println!("cargo:rustc-link-lib=dylib=crypto");

--- a/build.rs
+++ b/build.rs
@@ -45,8 +45,6 @@ fn main() {
         // While installing Rust please select x86_64-pc-windows-gnu
         // as the host triplet (custom installation step is required).
         HostType::Windows => Config::new("mgclient")
-            .target("windows-gnu")
-            .generator("MinGW Makefiles")
             .build(),
 
         HostType::MacOS => {

--- a/build.rs
+++ b/build.rs
@@ -44,8 +44,7 @@ fn main() {
         // https://github.com/memgraph/mgclient.
         // While installing Rust please select x86_64-pc-windows-gnu
         // as the host triplet (custom installation step is required).
-        HostType::Windows => Config::new("mgclient")
-            .build(),
+        HostType::Windows => Config::new("mgclient").build(),
 
         HostType::MacOS => {
             println!("MacOS detected. We will check if you have either the MacPorts or Homebrew package managers.");

--- a/src/connection/tests.rs
+++ b/src/connection/tests.rs
@@ -282,7 +282,7 @@ fn fetchone_summary() {
     }
 
     let summary = connection.summary().unwrap();
-    assert_eq!(6, summary.len());
+    assert_eq!(7, summary.len());
     for key in &[
         "cost_estimate",
         "has_more",
@@ -290,6 +290,7 @@ fn fetchone_summary() {
         "type",
         "planning_time",
         "plan_execution_time",
+        "run_id",
     ] {
         assert!(summary.contains_key(key as &str));
     }


### PR DESCRIPTION
- [x] `bindgen` needs libclang -> install it on Windows [WINDOWS] -> just a README note for now
- [x] Add proper OpenSSL lib search path [WINDOWS] -> it's possible to configure via env var
- [x] Revert to the right mgclient version -> depends on https://github.com/memgraph/mgclient/pull/34

Closes #31 