### PR TITLE
Fixing Docker builds on aarch64

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 [![](https://github.com/memgraph/rsmgclient/workflows/CI/badge.svg)](https://github.com/memgraph/rsmgclient/actions)
 
-`rsmgclient` is [Memgraph](https://memgraph.com/) database adapter for Rust
-programming language. `rsmgclient` crate is the current implementation of the
-adapter. It is implemented as a wrapper around
+`rsmgclient` is a [Memgraph](https://memgraph.com/) database adapter for Rust
+programming language. The `rsmgclient` crate is the current implementation of
+the adapter. It is implemented as a wrapper around
 [mgclient](https://github.com/memgraph/mgclient), the official Memgraph C/C++
 client library.
 
@@ -21,8 +21,8 @@ client library.
 
 ### Installing from crates.io
 
-Once prerequisites are met, if you want to use `rsmgclient` as library for your
-own Rust project, you can install it by using `cargo`:
+Once prerequisites are met, if you want to use `rsmgclient` as a library for
+your own Rust project, you can install it using `cargo`:
 
 ```bash
 cargo install rsmgclient
@@ -33,16 +33,17 @@ if you would like to change that please provide `OPENSSL_LIB_DIR` env variable.
 
 ### Building from Source
 
-To contribute into `rsmgclient` or just looking closely how it is made,
+To contribute into `rsmgclient` or just to look more closely how it is made,
 you will need:
 
 - Cloned [rsmgclient](https://github.com/memgraph/rsmgclient) repository
 - Properly initialized [mgclient](https://github.com/memgraph/mgclient), please
-  take care of the `mgclient` requirements
+  take care of the `mgclient` requirements.
 - [Memgraph Quick Start Guide](https://memgraph.com/docs/memgraph/quick-start)
 
 Once `rsmgclient` is cloned, you will need to build it and then you can run
 the test suite to verify it is working correctly:
+
 ```bash
 git submodule update --init
 cargo build
@@ -50,7 +51,7 @@ cargo build
 cargo test
 ```
 
-On MacOS, the build will try to detect OpenSSL by using MacPorts or Brew.
+On MacOS, the build will try to detect OpenSSL by using MacPorts or Homebrew.
 
 On Windows, `bindgen` requires `libclang` which is a part of LLVM. If LLVM is
 not already installed just go to the [LLVM

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -21,6 +21,7 @@ use super::value::{
 
 use std::collections::HashMap;
 use std::ffi::CString;
+use std::os::raw::c_char;
 use std::vec::IntoIter;
 
 /// Parameters for connecting to database.
@@ -693,7 +694,7 @@ impl Connection {
                         "Unable to make pull map integer value.",
                     )));
                 }
-                if bindings::mg_map_insert(mg_map, "n".as_ptr() as *const i8, mg_int) != 0 {
+                if bindings::mg_map_insert(mg_map, "n".as_ptr() as *const c_char, mg_int) != 0 {
                     self.status = ConnectionStatus::Bad;
                     bindings::mg_map_destroy(mg_map);
                     bindings::mg_value_destroy(mg_int);

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -20,6 +20,7 @@ use std::ffi::{CStr, CString};
 use std::fmt;
 use std::fmt::Formatter;
 use std::num::TryFromIntError;
+use std::os::raw::c_char;
 use std::slice;
 
 /// Representation of parameter value used in query.
@@ -165,7 +166,7 @@ fn mg_value_float(mg_value: *const bindings::mg_value) -> f64 {
     unsafe { bindings::mg_value_float(mg_value) }
 }
 
-pub(crate) unsafe fn c_string_to_string(c_str: *const i8, size: Option<u32>) -> String {
+pub(crate) unsafe fn c_string_to_string(c_str: *const c_char, size: Option<u32>) -> String {
     // https://github.com/rust-lang/rust/blob/master/library/std/src/ffi/c_str.rs#L1230
     let c_str = match size {
         Some(x) => CStr::from_bytes_with_nul_unchecked(slice::from_raw_parts(


### PR DESCRIPTION
This pull request fixes Docker builds on the aarch64 architecture. See [here](https://github.com/fede1024/rust-rdkafka/issues/121#issuecomment-486578947) for an explanation. This PR also fixes a couple of style/grammar issues in the top-level `README.md` file.