### PR TITLE
Fix build error on centos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,34 @@ jobs:
     - name: Run test
       run: cargo test
 
+  build_centos:
+    runs-on: ubuntu-latest
+    container: 
+      image: centos:8
+
+    steps:
+    - name: Modify repo files of centos image
+      run: |
+        sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-*
+        sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.centos.org|g' /etc/yum.repos.d/CentOS-*
+
+    - name: Install dependencies
+      run: |
+        yum install -y git cmake make gcc gcc-c++ openssl-devel epel-release clang
+
+    - name: Install rustup
+        run: |
+        curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+        source "$HOME/.cargo/env"
+
+    - uses: actions/checkout@v2
+      with:
+          submodules: true
+
+    - name: Build the project
+      run: |
+        cargo build --release
+
   build_macos:
     strategy:
       matrix:

--- a/build.rs
+++ b/build.rs
@@ -185,9 +185,14 @@ fn main() {
         .write_to_file(out_path.join("bindings.rs"))
         .expect("Couldn't write bindings!");
 
+    let lib_dir = if Path::new(&mgclient_out.join("lib64")).exists() {
+        "lib64"
+    } else {
+        "lib"
+    };
     println!(
         "cargo:rustc-link-search=native={}",
-        mgclient_out.join("lib").display()
+        mgclient_out.join(lib_dir).display()
     );
     println!("cargo:rustc-link-lib=static=mgclient");
     // If the following part of the code is pushed inside build_mgclient_xzy, linking is not done


### PR DESCRIPTION
Hi,

this PR potentially fixes #46 and #51.

I added a ci job that builds `rsmgclient` on `centos:8` image to demonstrate the fix. That job might deserve some polishing but should be good enough for demonstrating the fix.

The issue that caused the installation erros on centos-based linux distros was caused because of the following:

During build.rs, libmgclient was build and placed into `/rsmgclient/target/debug/build/rsmgclient-49e4c1ea816704fe/out/lib64`.
However, [line](https://github.com/memgraph/rsmgclient/blob/master/build.rs#L190) was linking to `lib` instead of `lib64`.

I added a check if `lib64` exists or not to "auto"-detect the issue and fix it.
However, I am not sure if this is the best fix to the underlying problem, that `mgclient` builds are exported to `lib` or `lib64` depending on the architecture. It might be better to address this in the `cmake` config of `mgclient` directly.

Still, this PR offers a fix. Feel free to comment, discuss, propose or make changes.

Yours, Martin