### PR TITLE
Handle Build Errors and upgrade OpenSSL to v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ client library.
 - [Rust](https://doc.rust-lang.org/cargo/getting-started/installation.html)
   1.42.0 or above
 - Prerequisites of [mgclient](https://github.com/memgraph/mgclient):
-  - A C compiler supporting C11 standard
-  - CMake 3.8 or newer
-  - OpenSSL 1.0.2 or newer
+    - A C compiler supporting C11 standard
+    - CMake 3.8 or newer
+    - OpenSSL 1.0.2 or newer
 
 ### Installing from crates.io
 
@@ -45,7 +45,7 @@ Once `rsmgclient` is cloned, you will need to build it and then you can run
 the test suite to verify it is working correctly:
 
 ```bash
-git submodule update --init
+git submodule update --init --recursive
 cargo build
 # Please run Memgraph based on the quick start guide
 cargo test

--- a/build.rs
+++ b/build.rs
@@ -16,6 +16,8 @@ extern crate bindgen;
 
 use cmake::Config;
 use std::env;
+use std::error::Error;
+use std::fmt::Display;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
@@ -27,16 +29,35 @@ enum HostType {
     Unknown,
 }
 
+#[derive(Debug)]
+enum BuildError {
+    IoError(String),
+    OpenSSL(String),
+    Unknown(String),
+}
+
+impl Display for BuildError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            BuildError::IoError(msg) => write!(f, "Failed to execute shell command: {}", msg),
+            BuildError::OpenSSL(msg) => write!(f, "OpenSSL Error: {}", msg),
+            BuildError::Unknown(msg) => write!(f, "Error: {}", msg),
+        }
+    }
+}
+
+impl Error for BuildError {}
+
 // NOTE: The code here is equivalent to [rust-openssl](https://github.com/sfackler/rust-openssl).
 // NOTE: We have to build mgclient and link the rust binary with the same SSL and Crypto libs.
 
-fn build_mgclient_macos() -> PathBuf {
+fn build_mgclient_macos() -> Result<PathBuf, BuildError> {
     println!("MacOS detected. We will check if you have either the MacPorts or Homebrew package managers.");
     println!("Checking for MacPorts...");
     let output = Command::new("/usr/bin/command")
         .args(["-v", "port"])
         .output()
-        .expect("Failed to execute shell command: '/usr/bin/command -v port'")
+        .map_err(|err| BuildError::IoError(format!("'/usr/bin/command -v port': {}", err)))?
         .stdout;
     let port_path = String::from_utf8(output).unwrap();
     if !port_path.is_empty() {
@@ -73,33 +94,50 @@ fn build_mgclient_macos() -> PathBuf {
         // With MacPorts, you don't need to pass in the OPENSSL_ROOT_DIR,
         // OPENSSL_CRYPTO_LIBRARY, and OPENSSL_SSL_LIBRARY options to CMake, PkgConfig
         // should take care of setting those variables.
-        Config::new("mgclient").build()
+        let path = Config::new("mgclient").build();
+        Ok(path)
     } else {
         println!("Macports not found.");
         println!("Checking for Homebrew...");
         let output = Command::new("/usr/bin/command")
             .args(["-v", "brew"])
             .output()
-            .expect("Failed to execute shell command: '/usr/bin/command -v brew'")
+            .map_err(|err| BuildError::IoError(format!("'/usr/bin/command -v brew': {}", err)))?
             .stdout;
         let brew_path = String::from_utf8(output).unwrap();
         if brew_path.is_empty() {
             println!("Homebrew not found.");
-            panic!(
+            BuildError::Unknown(
                 "We did not detect either MacPorts or Homebrew on your machine. We cannot proceed."
+                    .to_string(),
             );
         } else {
             println!("'brew' executable detected at {:?}", &brew_path);
             println!("Proceeding with installation assuming Homebrew is your package manager");
         }
+
         let path_openssl = if cfg!(target_arch = "aarch64") {
-            "/opt/homebrew/Cellar/openssl@1.1"
+            "/opt/homebrew/Cellar/openssl@3"
         } else {
-            "/usr/local/Cellar/openssl@1.1"
+            "/usr/local/Cellar/openssl@3"
         };
+        println!("Found OpenSSL at path: {}", path_openssl);
+
         let mut openssl_dirs = std::fs::read_dir(PathBuf::new().join(path_openssl))
-            .unwrap()
-            .map(|r| r.unwrap().path())
+            .map_err(|err| {
+                BuildError::OpenSSL(format!("Failed to read OpenSSL directory: '{}'", err))
+            })?
+            .filter_map(|r| match r {
+                Ok(entry) => Some(entry.path()),
+                Err(err) => {
+                    // Return the error as a BuildError
+                    Err(BuildError::OpenSSL(format!(
+                        "Failed to read directory entry: '{}'",
+                        err
+                    )))
+                    .ok()
+                }
+            })
             .collect::<Vec<PathBuf>>();
         openssl_dirs.sort_by(|a, b| {
             let a_time = a.metadata().unwrap().modified().unwrap();
@@ -112,7 +150,7 @@ fn build_mgclient_macos() -> PathBuf {
             openssl_root_path.join("lib").display()
         );
         let openssl_root = openssl_dirs[0].clone();
-        Config::new("mgclient")
+        let path = Config::new("mgclient")
             .define("OPENSSL_ROOT_DIR", format!("{}", openssl_root.display()))
             .define(
                 "OPENSSL_CRYPTO_LIBRARY",
@@ -128,26 +166,31 @@ fn build_mgclient_macos() -> PathBuf {
                     openssl_root.join("lib").join("libssl.dylib").display()
                 ),
             )
-            .build()
+            .build();
+
+        Ok(path)
     }
 }
 
-fn build_mgclient_linux() -> PathBuf {
-    Config::new("mgclient").build()
+fn build_mgclient_linux() -> Result<PathBuf, BuildError> {
+    let path = Config::new("mgclient").build();
+    Ok(path)
 }
 
-fn build_mgclient_windows() -> PathBuf {
+fn build_mgclient_windows() -> Result<PathBuf, BuildError> {
     let openssl_dir = PathBuf::from(
         std::env::var("OPENSSL_LIB_DIR")
             .unwrap_or_else(|_| "C:\\Program Files\\OpenSSL-Win64\\lib".to_string()),
     );
     println!("cargo:rustc-link-search=native={}", openssl_dir.display());
-    Config::new("mgclient")
+    let path = Config::new("mgclient")
         .define("OPENSSL_ROOT_DIR", format!("{}", openssl_dir.display()))
-        .build()
+        .build();
+
+    Ok(path)
 }
 
-fn main() {
+fn main() -> Result<(), BuildError> {
     let host_type = if cfg!(target_os = "linux") {
         HostType::Linux
     } else if cfg!(target_os = "windows") {
@@ -163,8 +206,8 @@ fn main() {
         HostType::Windows => build_mgclient_windows(),
         HostType::MacOS => build_mgclient_macos(),
         HostType::Linux => build_mgclient_linux(),
-        HostType::Unknown => panic!("Unknown operating system"),
-    };
+        HostType::Unknown => Err(BuildError::Unknown("Unknown operating system".to_string())),
+    }?;
 
     let mgclient_h = mgclient_out.join("include").join("mgclient.h");
     let mgclient_export_h = mgclient_out.join("include").join("mgclient-export.h");
@@ -212,4 +255,6 @@ fn main() {
         }
         HostType::Unknown => panic!("Unknown operating system"),
     }
+
+    Ok(())
 }

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -372,7 +372,7 @@ impl Connection {
         unsafe {
             bindings::mg_session_params_destroy(mg_session_params);
             if !trust_callback_ptr.is_null() {
-                Box::from_raw(trust_callback_ptr);
+                let _ = Box::from_raw(trust_callback_ptr);
             }
         };
 


### PR DESCRIPTION
When adding the `rsmgclient` to a rust project, the build fails due to the dependency on OpenSSL, but the error message that's displayed does not clearly identify the issue.

```
❯ cargo build
   Compiling rsmgclient v2.0.2
error: failed to run custom build command for `rsmgclient v2.0.2`

Caused by:
  process didn't exit successfully: `/Users/deej/code/graph-poc/target/debug/build/rsmgclient-369b1a59e35fb6da/build-script-build` (exit status: 101)
  --- stdout
  MacOS detected. We will check if you have either the MacPorts or Homebrew package managers.
  Checking for MacPorts...
  Macports not found.
  Checking for Homebrew...
  'brew' executable detected at "/opt/homebrew/bin/brew\n"
  Proceeding with installation assuming Homebrew is your package manager

  --- stderr
  thread 'main' panicked at /Users/deej/.cargo/registry/src/index.crates.io-6f17d22bba15001f/rsmgclient-2.0.2/build.rs:101:14:
  called `Result::unwrap()` on an `Err` value: Os { code: 2, kind: NotFound, message: "No such file or directory" }
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

Running `brew install openssl` installs a newer version of OpenSSL, `v3.4.1`, but the `build.rs` included in the project attempts to locate the `v1.1` directory as part of the build process.

This PR resolves https://github.com/memgraph/rsmgclient/issues/60 and https://github.com/memgraph/rsmgclient/issues/64 by upgrading the OpenSSL dependency to `v3`. The addition of a `BuildError` type allows developers to more easily identify the issue, and handle each distinct error case more specifically in the future.

Updated Error:
```
❯ cargo build
   Compiling rsmgclient v2.0.2 (/Users/deej/code/rsmgclient)
error: failed to run custom build command for `rsmgclient v2.0.2 (/Users/deej/code/rsmgclient)`

Caused by:
  process didn't exit successfully: `/Users/deej/code/rsmgclient/target/debug/build/rsmgclient-894cc56226a82700/build-script-build` (exit status: 1)
  --- stdout
  MacOS detected. We will check if you have either the MacPorts or Homebrew package managers.
  Checking for MacPorts...
  Macports not found.
  Checking for Homebrew...
  'brew' executable detected at "/opt/homebrew/bin/brew\n"
  Proceeding with installation assuming Homebrew is your package manager
  Found OpenSSL at path: /opt/homebrew/Cellar/openssl@1.1

  --- stderr
  Error: OpenSSL("Failed to read OpenSSL directory: 'No such file or directory (os error 2)'")
```