### PR TITLE
Fix CI for external contributions 

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# Global code owners
+# These users will be automatically assigned as reviewers for all PRs
+
+* @antejavor @gitbuda

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,12 +94,13 @@ jobs:
       with:
         targets: x86_64-pc-windows-msvc
 
-    - name: Install OpenSSL
+    - name: Install OpenSSL via vcpkg
       run: |
-        choco install openssl --version=3.0.5
+        vcpkg install openssl:x64-windows-static
         
     - name: Build the client
       run: cargo build --release --target=x86_64-pc-windows-msvc
       env:
-        OPENSSL_LIB_DIR: "C:\\Program Files\\OpenSSL-Win64\\lib"
-        OPENSSL_INCLUDE_DIR: "C:\\Program Files\\OpenSSL-Win64\\include"
+        OPENSSL_LIB_DIR: "C:\\vcpkg\\installed\\x64-windows-static\\lib"
+        OPENSSL_INCLUDE_DIR: "C:\\vcpkg\\installed\\x64-windows-static\\include"
+        OPENSSL_STATIC: "1"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,20 +19,6 @@ jobs:
       with:
         submodules: true
 
-    - name: Cache Memgraph Docker image
-      id: cache-memgraph-community-docker
-      uses: actions/cache@v4
-      with:
-        path: ~/memgraph
-        key: cache-memgraph-v${{ matrix.mgversion }}-docker-image
-    - name: Download Memgraph Docker image
-      if: steps.cache-memgraph-community-docker.outputs.cache-hit != 'true'
-      run: |
-        mkdir ~/memgraph
-        curl -L https://download.memgraph.com/memgraph/v${{ matrix.mgversion }}/docker/memgraph-${{ matrix.mgversion }}-docker.tar.gz > ~/memgraph/memgraph-docker.tar.gz
-    - name: Load Memgraph Docker image
-      run: docker load -i ~/memgraph/memgraph-docker.tar.gz
-
     - name: Set up Rust toolchain
       uses: dtolnay/rust-toolchain@stable
     - name: Run rust linter
@@ -43,7 +29,7 @@ jobs:
       run: cargo build --verbose
     - name: Run Memgraph
       run: |
-        docker run -d -p 7687:7687 memgraph/memgraph --telemetry-enabled=False
+        docker run -d -p 7687:7687 memgraph/memgraph:${{ matrix.mgversion }} --telemetry-enabled=False
     - name: Run test
       run: cargo test
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: CI
 
-on: [push]
+on: 
+  push:
+  pull_request:
 
 jobs:
   build_and_test_ubuntu:
@@ -13,13 +15,13 @@ jobs:
     steps:
     - name: Install system dependencies
       run: sudo apt-get install -y git cmake make gcc g++ libssl-dev
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         submodules: true
 
     - name: Cache Memgraph Docker image
       id: cache-memgraph-community-docker
-      uses: actions/cache@v1
+      uses: actions/cache@v4
       with:
         path: ~/memgraph
         key: cache-memgraph-v${{ matrix.mgversion }}-docker-image
@@ -31,9 +33,8 @@ jobs:
     - name: Load Memgraph Docker image
       run: docker load -i ~/memgraph/memgraph-docker.tar.gz
 
-    - uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
+    - name: Set up Rust toolchain
+      uses: dtolnay/rust-toolchain@stable
     - name: Run rust linter
       run: cargo clippy
     - name: Run rust formatter
@@ -64,7 +65,7 @@ jobs:
       run: |
         curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         submodules: true
 
@@ -87,7 +88,7 @@ jobs:
         sh rustup-init.sh -y --default-toolchain none
         rustup target add ${{ matrix.target }}
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
           submodules: true
 
@@ -124,7 +125,7 @@ jobs:
       run: |
         echo "C:/msys64/mingw${{ matrix.arch.mingw }}/bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
 
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
           submodules: true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,39 +82,24 @@ jobs:
       run: cargo build --release
 
   build_windows:
-    strategy:
-      matrix:
-        platform: [windows-2019]
-        target: [x86_64-pc-windows-gnu]
-        arch:
-          - { mingw: 64, msys: x86_64 }
-        mgversion: [3.4.0]
-    runs-on: ${{ matrix.platform }}
+    runs-on: windows-latest
 
     steps:
-    - name: Install Rustup using win.rustup.rs
-      run: |
-        # Disable the download progress bar which can cause perf issues
-        $ProgressPreference = "SilentlyContinue"
-        Invoke-WebRequest https://win.rustup.rs/ -OutFile rustup-init.exe
-        .\rustup-init.exe -y --default-host=x86_64-pc-windows-msvc --default-toolchain=none
-        rustup target add ${{ matrix.target }}
-        del rustup-init.exe
-
-    - uses: msys2/setup-msys2@v2
-      with:
-        msystem: MINGW${{ matrix.arch.mingw }}
-        update: true
-        install: git mingw-w64-${{ matrix.arch.msys }}-toolchain mingw-w64-${{ matrix.arch.msys }}-cmake mingw-w64-${{ matrix.arch.msys }}-openssl
-
-    - name: Add mingw${{ matrix.arch.mingw }} to PATH
-      run: |
-        echo "C:/msys64/mingw${{ matrix.arch.mingw }}/bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
-
     - uses: actions/checkout@v4
       with:
-          submodules: true
+        submodules: true
+
+    - name: Set up Rust toolchain
+      uses: dtolnay/rust-toolchain@stable
+      with:
+        targets: x86_64-pc-windows-msvc
+
+    - name: Install vcpkg dependencies
+      run: |
+        vcpkg install openssl:x64-windows-static
 
     - name: Build the client
-      run: |
-        cargo build --release --target=${{ matrix.target }}
+      run: cargo build --release --target=x86_64-pc-windows-msvc
+      env:
+        VCPKG_ROOT: C:\vcpkg
+        OPENSSL_DIR: C:\vcpkg\installed\x64-windows-static

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,12 +94,12 @@ jobs:
       with:
         targets: x86_64-pc-windows-msvc
 
-    - name: Install vcpkg dependencies
+    - name: Install OpenSSL
       run: |
-        vcpkg install openssl:x64-windows-static
-
+        choco install openssl --version=3.0.5
+        
     - name: Build the client
       run: cargo build --release --target=x86_64-pc-windows-msvc
       env:
-        VCPKG_ROOT: C:\vcpkg
-        OPENSSL_DIR: C:\vcpkg\installed\x64-windows-static
+        OPENSSL_LIB_DIR: "C:\\Program Files\\OpenSSL-Win64\\lib"
+        OPENSSL_INCLUDE_DIR: "C:\\Program Files\\OpenSSL-Win64\\include"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,8 @@ jobs:
   build_and_test_ubuntu:
     strategy:
      matrix:
-        platform: [ubuntu-20.04, ubuntu-22.04]
-        mgversion: [3.4.0]
+        platform: [ubuntu-24.04]
+        mgversion: [latest]
     runs-on: ${{ matrix.platform }}
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
      matrix:
         platform: [ubuntu-20.04, ubuntu-22.04]
-        mgversion: [2.19.0]
+        mgversion: [3.4.0]
     runs-on: ${{ matrix.platform }}
 
     steps:
@@ -102,7 +102,7 @@ jobs:
         target: [x86_64-pc-windows-gnu]
         arch:
           - { mingw: 64, msys: x86_64 }
-        mgversion: [1.5]
+        mgversion: [3.4.0]
     runs-on: ${{ matrix.platform }}
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,8 @@
 name: CI
 
 on: 
-  push:
   pull_request:
+    branches: [ master ]
 
 jobs:
   build_and_test_ubuntu:

--- a/README.md
+++ b/README.md
@@ -28,8 +28,16 @@ your own Rust project, you can install it using `cargo`:
 cargo install rsmgclient
 ```
 
-NOTE: The default OpenSSL path on Windows is `C:\Program Files\OpenSSL-Win64\lib`,
-if you would like to change that please provide `OPENSSL_LIB_DIR` env variable.
+**Windows Users**: If you encounter OpenSSL-related build issues, you can install OpenSSL via vcpkg:
+```bash
+vcpkg install openssl:x64-windows-static
+```
+Then set the environment variables:
+```bash
+set OPENSSL_LIB_DIR=C:\vcpkg\installed\x64-windows-static\lib
+set OPENSSL_INCLUDE_DIR=C:\vcpkg\installed\x64-windows-static\include
+set OPENSSL_STATIC=1
+```
 
 ### Building from Source
 
@@ -51,15 +59,14 @@ cargo build
 cargo test
 ```
 
-On MacOS, the build will try to detect OpenSSL by using MacPorts or Homebrew.
+On MacOS, the build will automatically detect OpenSSL using MacPorts or Homebrew.
 
-On Windows, `bindgen` requires `libclang` which is a part of LLVM. If LLVM is
-not already installed just go to the [LLVM
-download](https://releases.llvm.org/download.html) page, download and install
-`LLVM.exe` file (select the option to put LLVM on the PATH). In addition,
-default OpenSSL path is `C:\Program Files\OpenSSL-Win64\lib`, if you would like
-to change that please provide `OPENSSL_LIB_DIR` env variable during the build
-phase.
+On Windows, the build supports multiple OpenSSL configurations:
+- **Recommended**: The build will automatically use vcpkg to install OpenSSL if available
+- **Manual**: You can provide custom OpenSSL paths using `OPENSSL_LIB_DIR` and `OPENSSL_INCLUDE_DIR` environment variables
+- **Default**: Falls back to `C:\Program Files\OpenSSL-Win64\` if no custom paths are provided
+
+`bindgen` requires `libclang` which is part of LLVM. On Windows, if LLVM is not installed, download it from the [LLVM download page](https://releases.llvm.org/download.html) and install the `LLVM.exe` file (make sure to select the option to add LLVM to PATH).
 
 ## Documentation
 

--- a/build.rs
+++ b/build.rs
@@ -182,13 +182,23 @@ fn build_mgclient_linux() -> Result<PathBuf, BuildError> {
 }
 
 fn build_mgclient_windows() -> Result<PathBuf, BuildError> {
-    let openssl_dir = PathBuf::from(
+    let openssl_lib_dir = PathBuf::from(
         std::env::var("OPENSSL_LIB_DIR")
             .unwrap_or_else(|_| "C:\\Program Files\\OpenSSL-Win64\\lib".to_string()),
     );
-    println!("cargo:rustc-link-search=native={}", openssl_dir.display());
+    let openssl_include_dir = PathBuf::from(
+        std::env::var("OPENSSL_INCLUDE_DIR")
+            .unwrap_or_else(|_| "C:\\Program Files\\OpenSSL-Win64\\include".to_string()),
+    );
+    let openssl_root_dir = openssl_lib_dir.parent().unwrap_or(&openssl_lib_dir);
+    
+    println!("cargo:rustc-link-search=native={}", openssl_lib_dir.display());
+    
     let path = Config::new("mgclient")
-        .define("OPENSSL_ROOT_DIR", format!("{}", openssl_dir.display()))
+        .define("OPENSSL_ROOT_DIR", format!("{}", openssl_root_dir.display()))
+        .define("OPENSSL_INCLUDE_DIR", format!("{}", openssl_include_dir.display()))
+        .define("OPENSSL_CRYPTO_LIBRARY", format!("{}\\libcrypto.lib", openssl_lib_dir.display()))
+        .define("OPENSSL_SSL_LIBRARY", format!("{}\\libssl.lib", openssl_lib_dir.display()))
         .build();
 
     Ok(path)

--- a/build.rs
+++ b/build.rs
@@ -152,7 +152,10 @@ fn build_mgclient_macos() -> Result<PathBuf, BuildError> {
         let openssl_root = openssl_dirs[0].clone();
         let path = Config::new("mgclient")
             .define("OPENSSL_ROOT_DIR", format!("{}", openssl_root.display()))
-            .define("OPENSSL_INCLUDE_DIR", format!("{}", openssl_root.join("include").display()))
+            .define(
+                "OPENSSL_INCLUDE_DIR",
+                format!("{}", openssl_root.join("include").display()),
+            )
             .define(
                 "OPENSSL_CRYPTO_LIBRARY",
                 format!(

--- a/build.rs
+++ b/build.rs
@@ -285,8 +285,22 @@ fn main() -> Result<(), BuildError> {
             println!("cargo:rustc-link-lib=dylib=ssl");
         }
         HostType::Windows => {
-            println!("cargo:rustc-link-lib=dylib=libcrypto");
-            println!("cargo:rustc-link-lib=dylib=libssl");
+            // Check if we're using static OpenSSL (vcpkg)
+            let openssl_static = std::env::var("OPENSSL_STATIC").unwrap_or_default() == "1";
+            if openssl_static {
+                // Static linking - link with static libraries and system dependencies
+                println!("cargo:rustc-link-lib=static=libcrypto");
+                println!("cargo:rustc-link-lib=static=libssl");
+                // Windows system libraries required by static OpenSSL
+                println!("cargo:rustc-link-lib=crypt32");
+                println!("cargo:rustc-link-lib=ws2_32");
+                println!("cargo:rustc-link-lib=user32");
+                println!("cargo:rustc-link-lib=advapi32");
+            } else {
+                // Dynamic linking
+                println!("cargo:rustc-link-lib=dylib=libcrypto");
+                println!("cargo:rustc-link-lib=dylib=libssl");
+            }
         }
         HostType::MacOS => {
             println!("cargo:rustc-link-lib=dylib=crypto");

--- a/build.rs
+++ b/build.rs
@@ -191,14 +191,29 @@ fn build_mgclient_windows() -> Result<PathBuf, BuildError> {
             .unwrap_or_else(|_| "C:\\Program Files\\OpenSSL-Win64\\include".to_string()),
     );
     let openssl_root_dir = openssl_lib_dir.parent().unwrap_or(&openssl_lib_dir);
-    
-    println!("cargo:rustc-link-search=native={}", openssl_lib_dir.display());
-    
+
+    println!(
+        "cargo:rustc-link-search=native={}",
+        openssl_lib_dir.display()
+    );
+
     let path = Config::new("mgclient")
-        .define("OPENSSL_ROOT_DIR", format!("{}", openssl_root_dir.display()))
-        .define("OPENSSL_INCLUDE_DIR", format!("{}", openssl_include_dir.display()))
-        .define("OPENSSL_CRYPTO_LIBRARY", format!("{}\\libcrypto.lib", openssl_lib_dir.display()))
-        .define("OPENSSL_SSL_LIBRARY", format!("{}\\libssl.lib", openssl_lib_dir.display()))
+        .define(
+            "OPENSSL_ROOT_DIR",
+            format!("{}", openssl_root_dir.display()),
+        )
+        .define(
+            "OPENSSL_INCLUDE_DIR",
+            format!("{}", openssl_include_dir.display()),
+        )
+        .define(
+            "OPENSSL_CRYPTO_LIBRARY",
+            format!("{}\\libcrypto.lib", openssl_lib_dir.display()),
+        )
+        .define(
+            "OPENSSL_SSL_LIBRARY",
+            format!("{}\\libssl.lib", openssl_lib_dir.display()),
+        )
         .build();
 
     Ok(path)

--- a/build.rs
+++ b/build.rs
@@ -152,6 +152,7 @@ fn build_mgclient_macos() -> Result<PathBuf, BuildError> {
         let openssl_root = openssl_dirs[0].clone();
         let path = Config::new("mgclient")
             .define("OPENSSL_ROOT_DIR", format!("{}", openssl_root.display()))
+            .define("OPENSSL_INCLUDE_DIR", format!("{}", openssl_root.join("include").display()))
             .define(
                 "OPENSSL_CRYPTO_LIBRARY",
                 format!(


### PR DESCRIPTION
This PR fixes so the CI is being run on the external contribution PRs. 

The windows fix uses vcpkg and statically linked OpenSSL

Fixes: 
https://github.com/memgraph/rsmgclient/issues/69
