### PR TITLE
Update version and mgclient + `let` expressions in this position are unstable

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsmgclient"
-version = "3.0.0"
+version = "3.1.0"
 description = "Memgraph database adapter for Rust programming language."
 authors = ["Memgraph Contributors <tech@memgraph.com>"]
 license = "Apache-2.0"

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -590,11 +590,11 @@ impl Connection {
 
         match self.lazy {
             true => {
-                if self.status == ConnectionStatus::Executing
-                    && let Err(err) = self.pull(1)
-                {
-                    self.status = ConnectionStatus::Bad;
-                    return Err(err);
+                if self.status == ConnectionStatus::Executing {
+                    if let Err(err) = self.pull(1) {
+                        self.status = ConnectionStatus::Bad;
+                        return Err(err);
+                    }
                 }
                 // On success pull() has already updated the status.
 


### PR DESCRIPTION
Bump up version and fix 1.88 compatibility 