### PR TITLE
Bump version to 4.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rsmgclient"
-version = "3.1.0"
+version = "4.0.0"
 description = "Memgraph database adapter for Rust programming language."
 authors = ["Memgraph Contributors <tech@memgraph.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
The chrono/chrono-tz -> jiff migration (#80) changes public Date, LocalTime, LocalDateTime, and Duration types, which is a breaking change for consumers matching or constructing those variants.